### PR TITLE
Use standard benchmarking format instead.

### DIFF
--- a/examples/monte-carlo/cmd/bench/main.go
+++ b/examples/monte-carlo/cmd/bench/main.go
@@ -7,8 +7,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"ReconfigureIO/reco-sdaccel/benchmarks"
-
 	"github.com/ReconfigureIO/fixed"
 	"github.com/ReconfigureIO/fixed/host"
 	"github.com/ReconfigureIO/sdaccel/xcl"
@@ -42,7 +40,7 @@ func main() {
 	}
 
 	bm := testing.Benchmark(f)
-	benchmarks.GipedaResults("md5", bm)
+	fmt.Printf("%s\t%s\t%s\n", "monte-carlo", bm, bm.MemString())
 }
 
 func doit(world xcl.World, krnl *xcl.Kernel, B *testing.B) {


### PR DESCRIPTION
We published our machine-readable benchmarking format instead of the
standard human readable one. This make the output of `bench` in
monte-carlo look like the following:

```
monte-carlo     2000000000               0.00 ns/op     7531538316.70 MB/s             0 B/op          0 allocs/op
```