### PR TITLE
[WIP] Use LLVM for monte-carlo example

### DIFF
--- a/examples/monte-carlo/glide.lock
+++ b/examples/monte-carlo/glide.lock
@@ -1,16 +1,16 @@
-hash: 83dcf3f678b0a00fcc6daa4eb481ba1c91321478d4b9827910e070b092e4189b
-updated: 2018-02-07T17:35:29.635104418Z
+hash: b26f9265ea1fc53f46b587031dad86be0324ae1ce75d3ad3357405e16bf519e1
+updated: 2018-09-20T08:35:20.810214325-05:00
 imports:
 - name: github.com/ReconfigureIO/fixed
   version: 019e8e9cf87a7b55a8a8b78eecbc1d7fede75eec
   subpackages:
   - host
 - name: github.com/ReconfigureIO/math
-  version: ff0761c314860dfd24574211ae844b18b48056ca
+  version: 4df717df47b94250f0384d9a28a59585162c1ab4
   subpackages:
   - rand
 - name: github.com/ReconfigureIO/sdaccel
-  version: e93e5713d49cc1354dcd1d35cfaef85ba151e0a3
+  version: b7ebfa6c653cf1c6dbdb5107dc2a71e184b921b8
   subpackages:
   - axi/arbitrate
   - axi/memory

--- a/examples/monte-carlo/glide.yaml
+++ b/examples/monte-carlo/glide.yaml
@@ -1,7 +1,7 @@
 package: .
 import:
 - package: github.com/ReconfigureIO/sdaccel
-  version: v0.15.1
+  version: v0.19.0
   subpackages:
   - axi/memory
   - axi/protocol

--- a/examples/monte-carlo/input.go
+++ b/examples/monte-carlo/input.go
@@ -86,16 +86,18 @@ func Sim(rands <-chan fixed.Int26_6, p Param) Ret {
 
 		for i := uint16(p.days); i != 0; i-- {
 			W := <-rands
-			// The original formulation of this is as follows
-			// s0 = s0 + d.Mul(s0) + W.Mul(v.Mul(s0))
-			// we can factor out s0 to give the following
-			// s0 = s0.Mul(1 + d + W.Mul(v))
-			// 1 + d is constant, so refactor out
-			// hence the following
+			go func() {
+				// The original formulation of this is as follows
+				// s0 = s0 + d.Mul(s0) + W.Mul(v.Mul(s0))
+				// we can factor out s0 to give the following
+				// s0 = s0.Mul(1 + d + W.Mul(v))
+				// 1 + d is constant, so refactor out
+				// hence the following
 
-			// We'll separate out the m aggregator
-			// on s0 in the next for loop.
-			intermediates <- d + W.Mul(v)
+				// We'll separate out the m aggregator
+				// on s0 in the next for loop.
+				intermediates <- d + W.Mul(v)
+			}()
 		}
 
 	}()

--- a/examples/monte-carlo/reco.yml
+++ b/examples/monte-carlo/reco.yml
@@ -1,3 +1,4 @@
+compiler: rio
 context:
   output: fixed.Int26_6
   function: Rands


### PR DESCRIPTION
This updates our monte-carlo example to use our LLVM based compiler. 

Depends on https://github.com/ReconfigureIO/math/pull/6